### PR TITLE
Add Flask frontend and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+from flask import Flask, render_template, abort
+from pathlib import Path
+import markdown
+
+app = Flask(__name__)
+
+STORIES = {
+    'bosnian': Path('english_bosnian'),
+    'german': Path('english_german'),
+}
+
+@app.route('/')
+def index():
+    story_map = {}
+    for lang, path in STORIES.items():
+        stories = [p.stem for p in path.glob('*.md')]
+        story_map[lang] = stories
+    return render_template('index.html', stories=story_map)
+
+@app.route('/story/<lang>/<name>')
+def show_story(lang: str, name: str):
+    path = STORIES.get(lang)
+    if not path:
+        abort(404)
+    file_path = path / f"{name}.md"
+    if not file_path.exists():
+        abort(404)
+    md_content = file_path.read_text(encoding='utf-8')
+    html_content = markdown.markdown(md_content)
+    return render_template('story.html', content=html_content, title=name)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+flask>=2.3
+markdown>=3.4
 python-dotenv>=1.0.0
 requests>=2.31.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+    <title>Stories</title>
+</head>
+<body>
+    <h1>Available Stories</h1>
+    {% for lang, stories in stories.items() %}
+        <h2>{{ lang.title() }}</h2>
+        <ul>
+        {% for story in stories %}
+            <li><a href="/story/{{ lang }}/{{ story }}">{{ story.replace('_', ' ') }}</a></li>
+        {% endfor %}
+        </ul>
+    {% endfor %}
+</body>
+</html>

--- a/templates/story.html
+++ b/templates/story.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+    <title>{{ title }}</title>
+</head>
+<body>
+    <a href="/">Back to list</a>
+    <div>{{ content|safe }}</div>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,19 @@
+import pytest
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_index_lists_stories(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    # Should contain at least one known story
+    assert b'evening_at_a_bar' in resp.data
+
+def test_story_page(client):
+    resp = client.get('/story/bosnian/evening_at_a_bar')
+    assert resp.status_code == 200
+    assert b'Evening at a Bar' in resp.data

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from text_to_image import ImageProcessor
+
+
+def test_extract_json_from_markdown(tmp_path):
+    md = tmp_path / 'sample.md'
+    md.write_text('{"IMG": "a cat"}\nContent here', encoding='utf-8')
+    processor = ImageProcessor()
+    prompts = processor.extract_json_from_markdown(md)
+    assert prompts == {"IMG": "a cat"}
+    new_content = md.read_text(encoding='utf-8')
+    assert 'Content here' in new_content
+
+def test_replace_in_markdown():
+    content = 'Look at (IMG1) and (IMG2).'
+    replacements = {'IMG1': 'img1.png', 'IMG2': 'img2.png'}
+    processor = ImageProcessor()
+    result = processor.replace_in_markdown(content, replacements)
+    assert '(img1.png)' in result
+    assert '(img2.png)' in result


### PR DESCRIPTION
## Summary
- add simple Flask frontend to browse stories
- provide HTML templates for listing stories and displaying each story
- create unit tests for Flask app and ImageProcessor functions
- update requirements with Flask and Markdown

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: command not found)*